### PR TITLE
Hide metrics from public 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ RUN CGO_ENABLED=1 GOOS=linux go build \
 
 FROM ubuntu:20.04 as artifact
 
-RUN apt update
-RUN apt install -y git autoconf libtool g++ make
+RUN apt-get update
+RUN apt-get install -y git autoconf libtool g++ make
 
 # Install protobuf
 RUN cd \

--- a/server/server.go
+++ b/server/server.go
@@ -40,7 +40,6 @@ func setupRouter(ctx context.Context, logger *logrus.Logger) (context.Context, *
 	}
 
 	r.Mount("/", controller.TranslateRouter())
-	r.Get("/metrics", middleware.Metrics())
 
 	return ctx, r
 }
@@ -49,6 +48,16 @@ func setupRouter(ctx context.Context, logger *logrus.Logger) (context.Context, *
 func StartServer() {
 	serverCtx, logger := setupLogger(context.Background())
 	logger.WithFields(logrus.Fields{"prefix": "main"}).Info("Starting server")
+
+	go func() {
+		// setup metrics on another non-public port 9090
+		err := http.ListenAndServe(":9090", middleware.Metrics())
+		if err != nil {
+			sentry.CaptureException(err)
+			panic(fmt.Sprintf("metrics HTTP server start failed: %s", err.Error()))
+		}
+	}()
+
 	serverCtx, r := setupRouter(serverCtx, logger)
 	port := ":8195"
 	fmt.Println("Starting server: http://localhost" + port)

--- a/server/server.go
+++ b/server/server.go
@@ -53,7 +53,7 @@ func StartServer() {
 		// setup metrics on another non-public port 9090
 		err := http.ListenAndServe(":9090", middleware.Metrics())
 		if err != nil {
-			sentry.CaptureException(err)
+			raven.CaptureErrorAndWait(err, nil)
 			panic(fmt.Sprintf("metrics HTTP server start failed: %s", err.Error()))
 		}
 	}()


### PR DESCRIPTION
Related to https://github.com/brave/devops/issues/5867

Before: 
```
❯ http https://translate-relay.brave.com/metrics
HTTP/1.1 200 OK
Age: 9
Connection: keep-alive
Content-Encoding: gzip
Content-Length: 1475
Content-Type: text/plain; version=0.0.4; charset=utf-8
Date: Tue, 05 Oct 2021 14:48:53 GMT
Via: 1.1 d873eb6ebbb9da58c373c3c3b1843e77.cloudfront.net (CloudFront)
X-Amz-Cf-Id: _S8xWuclPl4NhpGam5B_6GPwiW1VUsaH60XJOnaPmgr7fh7nPDcb9g==
X-Amz-Cf-Pop: EWR52-C2
X-Cache: Hit from cloudfront
X-Edge-Origin-Shield-Skipped: 0
```

After
```
$ curl -I  https://translate-relay.brave.com/metrics
HTTP/2 404 
content-type: text/plain; charset=utf-8
content-length: 19
date: Wed, 06 Oct 2021 03:28:05 GMT
x-content-type-options: nosniff
x-cache: Error from cloudfront
via: 1.1 7140f0ca7678f315f05e94435ec1dea9.cloudfront.net (CloudFront)
x-amz-cf-pop: NRT57-P1
x-amz-cf-id: uIfaSIOi7KfyOyiiVKBrzhfLJhurTo_a5IsWIruHzZzIZvisZtuQDg==
```