### PR TITLE
Increase client timeout

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -54,7 +54,7 @@ func ServeStaticFile(w http.ResponseWriter, r *http.Request) {
 
 func getHTTPClient() *http.Client {
 	return &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 60,
 	}
 }
 


### PR DESCRIPTION
10s is too aggressive, so when we scale up, a lot of requests will hit 500
Relates to https://github.com/brave/devops/pull/7878