### PR TITLE
support for multiple endpoints, weighted routing

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -44,7 +44,7 @@ type LnxEndpointConfiguration struct {
 }
 
 // NewLnxEndpointConfiguration returns a new endpoint configuration based on a list of endpoints, weights and list of supported languages
-func NewLnxEndpointConfiguration(ctx context.Context, endpoints []string, weights []float64, languageLists []language.GoogleLanguageList) (*LnxEndpointConfiguration, error) {
+func NewLnxEndpointConfiguration(endpoints []string, weights []float64, languageLists []language.GoogleLanguageList) (*LnxEndpointConfiguration, error) {
 	if len(endpoints) != len(weights) || len(weights) != len(languageLists) {
 		return nil, fmt.Errorf("Number of endpoints must match number of weights and number of language lists")
 	}
@@ -146,7 +146,7 @@ func TranslateRouter(ctx context.Context) (chi.Router, error) {
 	}
 
 	var err error
-	LnxEndpoint, err = NewLnxEndpointConfiguration(context.Background(), endpoints, weights, lists)
+	LnxEndpoint, err = NewLnxEndpointConfiguration(endpoints, weights, lists)
 	if err != nil {
 		return r, fmt.Errorf("Failed to setup endpoint configuration: %v", err)
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,12 +1,17 @@
 package controller
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/brave-intl/bat-go/libs/logging"
@@ -16,17 +21,135 @@ import (
 	"github.com/go-chi/chi"
 )
 
-// LnxEndpoint specifies the remote Lnx translate server used by
-// brave-core, and it can be set to a mock server during testing.
-var LnxEndpoint = os.Getenv("LNX_HOST")
-var LnxAPIKey = os.Getenv("LNX_API_KEY")
-var languagePath = "/get-languages"
-var translatePath = "/translate"
+var (
+	LnxEndpoint   *LnxEndpointConfiguration
+	LnxAPIKey     = os.Getenv("LNX_API_KEY")
+	languagePath  = "/get-languages"
+	translatePath = "/translate"
+)
+
+// LnxEndpointConfiguration describes a configuration of lingvanex endpoints, their supported
+// languages and weights.
+type LnxEndpointConfiguration struct {
+	// A list of endpoint URLs.
+	Endpoints []string
+	// A list of default endpoint weights.
+	DefaultWeights []float64
+	// A GoogleLanguageList containing source language descriptions and target language descriptions.
+	LanguagePairList language.GoogleLanguageList
+	// A nested map of endpoint weights for a language pair.
+	// The first key represents the source language, the second key represents the target language, the 
+	// third key represents the endpoint URL and the value the corresponding weight for that endpoint.
+	LanguagePairWeights map[string]map[string]map[string]float64
+}
+
+// NewLnxEndpointConfiguration returns a new endpoint configuration based on a list of endpoints, weights and list of supported languages
+func NewLnxEndpointConfiguration(ctx context.Context, endpoints []string, weights []float64, languageLists []language.GoogleLanguageList) (*LnxEndpointConfiguration, error) {
+	if len(endpoints) != len(weights) || len(weights) != len(languageLists) {
+		return nil, fmt.Errorf("Number of endpoints must match number of weights and number of language lists")
+	}
+
+	conf := LnxEndpointConfiguration{
+		Endpoints:           endpoints,
+		DefaultWeights:      weights,
+		LanguagePairList:    language.GoogleLanguageList{Sl: make(map[string]string), Tl: make(map[string]string)},
+		LanguagePairWeights: make(map[string]map[string]map[string]float64),
+	}
+
+	for i, endpoint := range endpoints {
+		// get the list of supported languages for the current endpoint
+		list := languageLists[i]
+
+		// iterate through the source languages the current endpoint supports
+		for sl, sldesc := range list.Sl {
+			// add the source language description to the merged language pair list
+			conf.LanguagePairList.Sl[sl] = sldesc
+
+			// check if the source language weight map already exists in the language pair weights
+			if _, ok := conf.LanguagePairWeights[sl]; !ok {
+				// if not, create a new weight map for the source language
+				conf.LanguagePairWeights[sl] = make(map[string]map[string]float64)
+			}
+
+			for tl, tldesc := range list.Tl {
+				// add the target language description to the merged language pair list
+				conf.LanguagePairList.Tl[tl] = tldesc
+
+				// check if the weight map for the source / target language pair already exists
+				if _, ok := conf.LanguagePairWeights[sl][tl]; !ok {
+					// if not, create a new weight map for it
+					conf.LanguagePairWeights[sl][tl] = make(map[string]float64)
+				}
+				 // set the default weight for the current endpoint for the source-target language pair
+				conf.LanguagePairWeights[sl][tl][endpoint] = conf.DefaultWeights[i]
+			}
+		}
+	}
+	return &conf, nil
+}
+
+// GetEndpoint returns the endpoint which should be used based on the weights and languages supported.
+func (c *LnxEndpointConfiguration) GetEndpoint(from, to string) string {
+	// initialize total weight and incrementals.
+	total := 0.0
+	incrementals := []float64{}
+
+	// retrieve the nested map of language pair weights.
+	weights := c.LanguagePairWeights[from][to]
+
+	// iterate through the Endpoints array, accumulating the total weight and storing the intermediate sums in incrementals.
+	for _, endpoint := range c.Endpoints {
+		total += weights[endpoint]
+		incrementals = append(incrementals, total)
+	}
+
+	// generate a random number between 0 and total.
+	r := rand.Float64() * total
+
+	// find the endpoint with the smallest incremental weight greater than r.
+	for i, incremental := range incrementals {
+		if r < incremental {
+			return c.Endpoints[i]
+		}
+	}
+	// otherwise default to the first endpoint
+	return c.Endpoints[0]
+}
 
 // TranslateRouter add routers for translate requests and translate script
 // requests.
-func TranslateRouter() chi.Router {
+func TranslateRouter(ctx context.Context) (chi.Router, error) {
 	r := chi.NewRouter()
+
+	var weights []float64
+	endpoints := strings.Split(os.Getenv("LNX_HOST"), ",")
+	for _, weight := range strings.Split(os.Getenv("LNX_WEIGHTS"), ",") {
+		if len(weight) > 0 {
+			weight, err := strconv.ParseFloat(weight, 64)
+			if err != nil {
+				return r, fmt.Errorf("Must pass at least one endpoint via LNX_HOST and one weight via LNX_WEIGHTS: %v", err)
+			}
+			weights = append(weights, weight)
+		}
+	}
+	if len(endpoints) == 1 && len(weights) == 0 {
+		weights = append(weights, 1)
+	}
+
+	var lists []language.GoogleLanguageList
+	for _, endpoint := range endpoints {
+		list, err := getLanguageList(ctx, endpoint)
+		if err != nil {
+			panic(err)
+		}
+		lists = append(lists, *list)
+	}
+
+	var err error
+	LnxEndpoint, err = NewLnxEndpointConfiguration(context.Background(), endpoints, weights, lists)
+	if err != nil {
+		return r, fmt.Errorf("Failed to setup endpoint configuration: %v", err)
+	}
 
 	r.Post("/translate_a/t", middleware.InstrumentHandler("Translate", http.HandlerFunc(Translate)).ServeHTTP)
 	r.Get("/translate_a/l", middleware.InstrumentHandler("GetLanguageList", http.HandlerFunc(GetLanguageList)).ServeHTTP)
@@ -35,7 +158,7 @@ func TranslateRouter() chi.Router {
 	r.Get("/static/v1/js/element/main.js", middleware.InstrumentHandler("ServeStaticFile", http.HandlerFunc(ServeStaticFile)).ServeHTTP)
 	r.Get("/static/v1/css/translateelement.css", middleware.InstrumentHandler("ServeStaticFile", http.HandlerFunc(ServeStaticFile)).ServeHTTP)
 
-	return r
+	return r, nil
 }
 
 func ServeStaticFile(w http.ResponseWriter, r *http.Request) {
@@ -59,25 +182,21 @@ func getHTTPClient() *http.Client {
 	}
 }
 
-// GetLanguageList send a request to Lingvanex server and convert the response
-// into google format and reply back to the client.
-func GetLanguageList(w http.ResponseWriter, r *http.Request) {
-	logger := logging.FromContext(r.Context())
+func getLanguageList(ctx context.Context, endpoint string) (*language.GoogleLanguageList, error) {
+	logger := logging.FromContext(ctx)
 
 	// Send a get language list request to Lnx
-	req, err := http.NewRequest("GET", LnxEndpoint+languagePath, nil)
+	req, err := http.NewRequest("GET", endpoint+languagePath, nil)
 	req.Header.Add("Authorization", "Bearer "+LnxAPIKey)
 
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error creating Lnx request: %v", err), http.StatusInternalServerError)
-		return
+		return nil, fmt.Errorf("Error creating Lnx request: %v", err)
 	}
 
 	client := getHTTPClient()
 	lnxResp, err := client.Do(req)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error sending request to Lnx server: %v", err), http.StatusInternalServerError)
-		return
+		return nil, fmt.Errorf("Error sending request to Lnx server: %v", err)
 	}
 	defer func() {
 		err := lnxResp.Body.Close()
@@ -86,30 +205,31 @@ func GetLanguageList(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	// Set response header
-	w.Header().Set("Content-Type", lnxResp.Header["Content-Type"][0])
-	w.WriteHeader(lnxResp.StatusCode)
-
-	// Copy resonse body if status is not OK
-	if lnxResp.StatusCode != http.StatusOK {
-		_, err = io.Copy(w, lnxResp.Body)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("Error copying Lnx response body: %v", err), http.StatusInternalServerError)
-		}
-		return
-	}
-
 	// Convert to google format language list and write it back
 	lnxBody, err := ioutil.ReadAll(lnxResp.Body)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error reading Lnx response body: %v", err), http.StatusInternalServerError)
-		return
+		return nil, fmt.Errorf("Error reading Lnx response body: %v", err)
 	}
-	body, err := language.ToGoogleLanguageList(lnxBody)
+	list, err := language.ToGoogleLanguageList(lnxBody)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error converting to google language list: %v", err), http.StatusInternalServerError)
+		return nil, fmt.Errorf("Error converting to google language list: %v", err)
+	}
+
+	return list, nil
+}
+
+// GetLanguageList send a request to Lingvanex server and convert the response
+// into google format and reply back to the client.
+func GetLanguageList(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+
+	body, err := json.Marshal(LnxEndpoint.LanguagePairList)
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	_, err = w.Write(body)
 	if err != nil {
 		logger.Error().Err(err).Msg("Error writing response body for translate requests")
@@ -124,7 +244,14 @@ func Translate(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Access-Control-Allow-Origin", "*") // same as Google response
 
-	req, isAuto, err := translate.ToLingvanexRequest(r, LnxEndpoint+translatePath)
+	to, from, err := translate.GetLanguageParams(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error converting to LnxEndpoint request: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	endpoint := LnxEndpoint.GetEndpoint(from, to)
+	req, isAuto, err := translate.ToLingvanexRequest(r, endpoint+translatePath)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error converting to LnxEndpoint request: %v", err), http.StatusBadRequest)
 		return

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,8 +9,6 @@ import (
 )
 
 func TestNewLnxEndpointConfiguration(t *testing.T) {
-	ctx := context.Background()
-
 	lists := []language.GoogleLanguageList{
 		language.GoogleLanguageList{
 			Sl: map[string]string{"en":"English", "es":"Spanish", "it": "Italian"},
@@ -25,7 +22,7 @@ func TestNewLnxEndpointConfiguration(t *testing.T) {
 	endpoints := []string{"endpoint1.com", "endpoint2.com"}
 	weights := []float64{0.5, 0.5}
 
-	conf, err := NewLnxEndpointConfiguration(ctx, endpoints, weights, lists)
+	conf, err := NewLnxEndpointConfiguration(endpoints, weights, lists)
 	assert.NoError(t, err)
 
 	assert.Equal(t, endpoints, conf.Endpoints)
@@ -43,7 +40,6 @@ func TestNewLnxEndpointConfiguration(t *testing.T) {
 }
 
 func TestLnxEndpointConfiguration_GetEndpoint(t *testing.T) {
-	ctx := context.Background()
 	lists := []language.GoogleLanguageList{
 		language.GoogleLanguageList{
 			Sl: map[string]string{"en":"English", "es":"Spanish", "it": "Italian"},
@@ -57,7 +53,7 @@ func TestLnxEndpointConfiguration_GetEndpoint(t *testing.T) {
 	endpoints := []string{"endpoint1.com", "endpoint2.com"}
 	weights := []float64{0.5, 0.5}
 
-	conf, err := NewLnxEndpointConfiguration(ctx, endpoints, weights, lists)
+	conf, err := NewLnxEndpointConfiguration(endpoints, weights, lists)
 	assert.NoError(t, err)
 
 	t.Run("random selection", func(t *testing.T) {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/brave/go-translate/language"
+)
+
+func TestNewLnxEndpointConfiguration(t *testing.T) {
+	ctx := context.Background()
+
+	lists := []language.GoogleLanguageList{
+		language.GoogleLanguageList{
+			Sl: map[string]string{"en":"English", "es":"Spanish", "it": "Italian"},
+			Tl: map[string]string{"en":"English", "es":"Spanish", "it": "Italian"},
+		},
+		language.GoogleLanguageList{
+			Sl: map[string]string{"en":"English", "es":"Spanish", "de": "Deutsch"},
+			Tl: map[string]string{"en":"English", "es":"Spanish", "de": "Deutsch"},
+		},
+	}
+	endpoints := []string{"endpoint1.com", "endpoint2.com"}
+	weights := []float64{0.5, 0.5}
+
+	conf, err := NewLnxEndpointConfiguration(ctx, endpoints, weights, lists)
+	assert.NoError(t, err)
+
+	assert.Equal(t, endpoints, conf.Endpoints)
+	assert.Equal(t, weights, conf.DefaultWeights)
+
+	assert.NotNil(t, conf.LanguagePairList)
+	assert.NotEmpty(t, conf.LanguagePairWeights)
+
+	assert.Equal(t, conf.LanguagePairWeights["en"]["it"], map[string]float64{"endpoint1.com": 0.5})
+	assert.Equal(t, conf.LanguagePairWeights["it"]["en"], map[string]float64{"endpoint1.com": 0.5})
+	assert.Equal(t, conf.LanguagePairWeights["en"]["de"], map[string]float64{"endpoint2.com": 0.5})
+	assert.Equal(t, conf.LanguagePairWeights["de"]["en"], map[string]float64{"endpoint2.com": 0.5})
+	assert.Equal(t, conf.LanguagePairWeights["en"]["es"], map[string]float64{"endpoint1.com": 0.5, "endpoint2.com": 0.5})
+	assert.Equal(t, conf.LanguagePairWeights["es"]["en"], map[string]float64{"endpoint1.com": 0.5, "endpoint2.com": 0.5})
+}
+
+func TestLnxEndpointConfiguration_GetEndpoint(t *testing.T) {
+	ctx := context.Background()
+	lists := []language.GoogleLanguageList{
+		language.GoogleLanguageList{
+			Sl: map[string]string{"en":"English", "es":"Spanish", "it": "Italian"},
+			Tl: map[string]string{"en":"English", "es":"Spanish", "it": "Italian"},
+		},
+		language.GoogleLanguageList{
+			Sl: map[string]string{"en":"English", "es":"Spanish", "de": "Deutsch"},
+			Tl: map[string]string{"en":"English", "es":"Spanish", "de": "Deutsch"},
+		},
+	}
+	endpoints := []string{"endpoint1.com", "endpoint2.com"}
+	weights := []float64{0.5, 0.5}
+
+	conf, err := NewLnxEndpointConfiguration(ctx, endpoints, weights, lists)
+	assert.NoError(t, err)
+
+	t.Run("random selection", func(t *testing.T) {
+		from := "en"
+		to := "es"
+		countOne := 0
+		countTwo := 0
+
+		for i := 0; i<2000; i++ {
+			got := conf.GetEndpoint(from, to)
+			if got == "endpoint1.com" {
+				countOne++
+			} else if got == "endpoint2.com" {
+				countTwo++
+			}
+		}
+		assert.Less(t, 900, countTwo)
+		assert.Greater(t, 1100, countTwo)
+		assert.Less(t, 900, countOne)
+		assert.Greater(t, 1100, countOne)
+	})
+
+	t.Run("first endpoint", func(t *testing.T) {
+		from := "en"
+		to := "it"
+		expected := "endpoint1.com"
+
+		for i := 0; i<100; i++ {
+			got := conf.GetEndpoint(from, to)
+			assert.Equal(t, expected, got)
+		}
+	})
+
+	t.Run("second endpoint", func(t *testing.T) {
+		from := "en"
+		to := "de"
+		expected := "endpoint2.com"
+
+		for i := 0; i<100; i++ {
+			got := conf.GetEndpoint(from, to)
+			assert.Equal(t, expected, got)
+		}
+	})
+}

--- a/language/language.go
+++ b/language/language.go
@@ -193,7 +193,7 @@ type GoogleLanguageList struct {
 
 // ToGoogleLanguageList unmarshal a Lnx language list and marshal a corresponding
 // google language list and return it.
-func ToGoogleLanguageList(body []byte) ([]byte, error) {
+func ToGoogleLanguageList(body []byte) (*GoogleLanguageList, error) {
 	var lnxLangList []Language
 	err := json.Unmarshal(body, &lnxLangList)
 	if err != nil {
@@ -212,7 +212,7 @@ func ToGoogleLanguageList(body []byte) ([]byte, error) {
 		googleLangList.Sl[val] = lang.Name
 		googleLangList.Tl[val] = lang.Name
 	}
-	return json.Marshal(googleLangList)
+	return &googleLangList, nil
 }
 
 func init() {

--- a/language/language_test.go
+++ b/language/language_test.go
@@ -1,6 +1,7 @@
 package language
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,11 @@ func TestToGoogleLanguageList(t *testing.T) {
 	msList := []byte(`[{"code_alpha_1": "en", "codeName": "English", "rtl": false}, {"code_alpha_1": "zh-Hans", "codeName": "Chinese (Simplified)", "rtl": false}]`)
 	googleList := []byte(`{"sl":{"en":"English","zh-CN":"Chinese (Simplified)"},"tl":{"en":"English","zh-CN":"Chinese (Simplified)"}}`)
 	list, err := ToGoogleLanguageList(msList)
-
 	assert.Equal(t, nil, err)
-	assert.Equal(t, googleList, list)
+
+	var expected GoogleLanguageList
+	err = json.Unmarshal(googleList, &expected)
+	assert.Equal(t, nil, err)
+
+	assert.Equal(t, expected, *list)
 }

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -66,21 +66,28 @@ type LingvanexResponseBody struct {
 	TranslatedText []string `json:"translatedText"`
 }
 
+func GetLanguageParams(r *http.Request) (string, string, error) {
+	// Parse google format query parameters
+	slVals := r.URL.Query()["sl"]
+	if len(slVals) != 1 {
+		return "", "", errors.New("invalid query parameter format: There should be one sl parameter")
+	}
+	tlVals := r.URL.Query()["tl"]
+	if len(tlVals) != 1 {
+		return "", "", errors.New("invalid query parameter format: There should be one tl parameter")
+	}
+	return slVals[0], tlVals[0], nil
+}
+
 // ToLingvanexRequest parses the input Google format translate request and
 // return a corresponding Lingvanex format request.
 func ToLingvanexRequest(r *http.Request, serverURL string) (*http.Request, bool, error) {
 	lnxURL := serverURL
-	// Parse google format query parameters
-	slVals := r.URL.Query()["sl"]
-	if len(slVals) != 1 {
-		return nil, false, errors.New("invalid query parameter format: There should be one sl parameter")
+
+	from, to, err := GetLanguageParams(r)
+	if err != nil {
+		return nil, false, err
 	}
-	tlVals := r.URL.Query()["tl"]
-	if len(tlVals) != 1 {
-		return nil, false, errors.New("invalid query parameter format: There should be one tl parameter")
-	}
-	from := slVals[0]
-	to := tlVals[0]
 
 	reqsProcessed.With(prometheus.Labels{
 		"from_lang": from,


### PR DESCRIPTION
this PR adds support for specifying multiple lingvanex endpoints and performing weighted routing between them. on startup, the supported languages are fetched for each endpoint and the final weights are determined on a per language pair basis.

the new support was added in a backward compatible basis, if only a single endpoint is specified and no weights - it is automatically used for all requests.